### PR TITLE
Fix backwards PMKAlertController Canceled logic

### DIFF
--- a/Categories/UIKit/PMKAlertController.swift
+++ b/Categories/UIKit/PMKAlertController.swift
@@ -40,7 +40,7 @@ public class PMKAlertController {
 
     public func addActionWithTitle(title: String, style: UIAlertActionStyle = .Default) -> UIAlertAction {
         let action = UIAlertAction(title: title, style: style) { action in
-            if style == UIAlertActionStyle.Cancel {
+            if style != UIAlertActionStyle.Cancel {
                 self.fulfill(action)
             } else {
                 self.reject(Error.Cancelled)


### PR DESCRIPTION
It was rejecting the non-cancels and fulfilling the cancels!
